### PR TITLE
msm8974-common: rootdir: Clean up fstab

### DIFF
--- a/rootdir/etc/fstab.qcom
+++ b/rootdir/etc/fstab.qcom
@@ -9,10 +9,10 @@
 /dev/block/platform/msm_sdcc.1/by-name/boot         /boot            emmc    defaults                                                                    recoveryonly
 /dev/block/platform/msm_sdcc.1/by-name/recovery     /recovery        emmc    defaults                                                                    recoveryonly
 /dev/block/platform/msm_sdcc.1/by-name/misc         /misc            emmc    defaults                                                                    recoveryonly
-/dev/block/platform/msm_sdcc.1/by-name/system       /system          ext4    ro,seclabel,noatime,data=ordered                                            wait
-/dev/block/platform/msm_sdcc.1/by-name/userdata     /data            f2fs    rw,nosuid,nodev,noatime,nodiratime,inline_xattr	        	         wait,check,formattable,encryptable=/dev/block/platform/msm_sdcc.1/by-name/extra
+/dev/block/platform/msm_sdcc.1/by-name/system       /system          ext4    ro,barrier=1                                                                wait
+/dev/block/platform/msm_sdcc.1/by-name/userdata     /data            f2fs    noatime,nosuid,nodev,inline_xattr                                           wait,check,formattable,encryptable=/dev/block/platform/msm_sdcc.1/by-name/extra
 /dev/block/platform/msm_sdcc.1/by-name/userdata     /data            ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,journal_async_commit,errors=panic wait,check,formattable,encryptable=/dev/block/platform/msm_sdcc.1/by-name/extra
-/dev/block/platform/msm_sdcc.1/by-name/cache        /cache           f2fs    rw,nosuid,nodev,noatime,nodiratime,inline_xattr		                 wait,check,formattable
+/dev/block/platform/msm_sdcc.1/by-name/cache        /cache           f2fs    noatime,nosuid,nodev,inline_xattr                                           wait,check,formattable
 /dev/block/platform/msm_sdcc.1/by-name/cache        /cache           ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,journal_async_commit,errors=panic wait,check,formattable
 
 /dev/block/platform/msm_sdcc.1/by-name/radio        /firmware/radio  vfat    ro,shortname=lower,uid=1000,gid=1000,dmask=227,fmask=337,context=u:object_r:firmware_file:s0                    wait


### PR DESCRIPTION
 * Bring system partition mount flags inline with the standards,
   removing never seen seclabel and useless data=ordered option,
   considering that system is a read-only partition.

 * Remove nodiratime mount flag from data and cache partition entries,
   as noatime already implies nodiratime.

Change-Id: Ida6867c89caa126a698fcd9f6cc06500de18d598